### PR TITLE
Fix EXCLUDED_COUNTRY_CODES regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ chmod 700 mtc
 
 - Change the `RULES_DIR` variable to point to the folder where the `mullvad.rules` file from this repository is located. If you cloned the repo, it should be inside the `mullvad-tailscale` folder.
 
-- Modify the `EXCLUDED_COUNTRY_CODES` if you want to exclude any countries from the VPN connection (don't connect to these countries). If you do not want to exclude any CC set this variable to `'(0)'`. If you want to add more, just follow the pattern.
+- Modify the `EXCLUDED_COUNTRY_CODES` if you want to exclude any countries from the VPN connection (don't connect to these countries). If you do not want to exclude any CC set this variable to `''`. If you want to add more, just follow the pattern.
 
 5. Edit the `mullvad.rules` file:
 

--- a/mtc
+++ b/mtc
@@ -4,11 +4,14 @@
 
 # ---------------------------
 # CONFIG VARIABLES YOU SHOULD CHANGE
-RULES_DIR=$HOME/LINUX/VPN # Path to where mullvad.rules file is located
-EXCLUDE_COUNTRY_CODES='(us|ca|jp|au|hk|gb)' # Country codes to avoid
+RULES_DIR=$HOME/Software/git/mullvad-tailscale/ # Path to where mullvad.rules file is located
+EXCLUDE_COUNTRY_CODES='' # Country codes to avoid.
+# Set to '' if no country should be excluded.
+#
 # ----------------------------
 
 DNS='default'
+[ -z "$EXCLUDE_COUNTRY_CODES" ] && EXCLUDE_COUNTRY_CODES='^$'
 
 usage() {
     echo "usage:"


### PR DESCRIPTION
Setting EXCLUDED_COUNTRY_CODES to '(0)' excludes all servers, because all server names contain a 0. This instructs the user to set it to '' instead, in which case it is then set to '^$', in order not to exclude any server names.