### PR TITLE
Fix version check syntax for bash 4.x

### DIFF
--- a/mnf
+++ b/mnf
@@ -45,7 +45,7 @@ bash_version_check() {
   # This script requires Bash >= 4.4 since it uses readarray.
   local error="This script requires Bash >=4.4."
   if [[ ${BASH_VERSINFO[0]} = 4 ]]; then
-    if [[ ${BASH_VERSINFO[1]-lt 4 } ]]; then
+    if [[ ${BASH_VERSINFO[1]} -lt 4 ]]; then
       die "$error"
     fi
   elif [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then


### PR DESCRIPTION
There's a small typo in the version check that affects people running bash 4.x.