### PR TITLE
NFT rule fix and QOL changes

### DIFF
--- a/mnf
+++ b/mnf
@@ -2,7 +2,7 @@
 
 # ---------------------------
 # CONFIG VARIABLES YOU SHOULD CHANGE
-RULES_DIR="$HOME/Software/mullvad-tailscale/" # Path to the dir in which mullvad.rules file is located.
+RULES_DIR="$(dirname "$(realpath "$0")")" # Path to the directory where the script is located.
 EXCLUDE_COUNTRY_CODES=(us ca jp au hk gb) # Country codes to avoid. Set to '' to allow all.
 # INCLUDE_COUNTRY_CODES=(fr gb) # Country codes to connect to. Uncomment to use. Overridden by -c option. Overrides EXCLUDE_COUNTRY_CODES.
 # DNS=(1.1.1.1 8.8.8.8) # Custom DNS servers for Mullvad. Uncomment to use. Overridden by -d option.

--- a/mnf
+++ b/mnf
@@ -254,7 +254,7 @@ up() {
 
   # Connect to Mullvad
   printf "[INFO] Connecting to server '%s'...\n" "$relay"
-  prefix_output mullvad relay set hostname "$relay"
+  prefix_output mullvad relay set location "$relay"
   prefix_output mullvad connect -w
 
   if [[ "$zerotier" = true ]]; then

--- a/mullvad.rules
+++ b/mullvad.rules
@@ -3,32 +3,25 @@ define RESOLVER_ADDRS = {
 }
 
 define EXCLUDED_IPS = {
-    100.200.300.400,
-    100.500.600.700
+	100.64.0.0/10
 }
 
 # Comment the following block if you do not want IPv6 support.
 define EXCLUDED_IPV6 = {
-    exam:ple:change:exam:ple:add:ress:bf04,
-    exam:ple:change:exam:ple:add:ress:6951
+	fd7a:115c:a1e0::/48
 }
 
 table inet mullvad-ts {
-  chain excludeOutgoing {
-    type route hook output priority 0; policy accept;
-    ip daddr $EXCLUDED_IPS ct mark set 0x00000f41 meta mark set 0x6d6f6c65;
-    # Comment the following line if you do not want IPv6 support.
-    ip6 daddr $EXCLUDED_IPV6 ct mark set 0x00000f41 meta mark set 0x6d6f6c65;
-  }
-
-  chain allow-incoming {
-    type filter hook input priority -100; policy accept;
-    iifname "tailscale0" ct mark set 0x00000f41 meta mark set 0x6d6f6c65;
-  }
-
-  chain excludeDns {
-    type filter hook output priority -10; policy accept;
-    ip daddr $RESOLVER_ADDRS udp dport 53 ct mark set 0x00000f41 meta mark set 0x6d6f6c65;
-    ip daddr $RESOLVER_ADDRS tcp dport 53 ct mark set 0x00000f41 meta mark set 0x6d6f6c65;
-  }
+        chain outgoing {
+                type route hook output priority -100; policy accept;
+                ip daddr $EXCLUDED_IPS ct mark set 0x00000f41 meta mark set 0x6d6f6c65;
+                # Comment the following line if you do not want IPv6 support.
+                ip6 daddr $EXCLUDED_IPV6 ct mark set 0x00000f41 meta mark set 0x6d6f6c65;
+        }
+        chain prerouting {
+                type filter hook prerouting priority -100; policy accept;
+                ip saddr $EXCLUDED_IPS ct mark set 0x00000f41 meta mark set 0x6d6f6c65;
+                # Comment the following line if you do not want IPv6 support.
+                ip6 saddr $EXCLUDED_IPV6 ct mark set 0x00000f41 meta mark set 0x6d6f6c65;
+        }
 }


### PR DESCRIPTION
Hi @r3nor, 

I applied the [fix](https://github.com/r3nor/mullvad-tailscale/issues/18) suggested by @immrspy and made some minor tweaks to the "default experience": 

- I used the default IPv4 and IPv6 address ranges used by tailscale (see [ipv4](https://tailscale.com/kb/1304/ip-pool) and [IPv6](https://tailscale.com/kb/1121/ipv6)). 

- I changed the mnf bash script so it uses the mullvad.rules file directly.

Thanks for your work so far. Hope this helps, feel free to reject anything you don't like :)